### PR TITLE
pypika 0.51.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - python
     - typing_extensions >=4.5.0  # [py<311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,11 @@ about:
   dev_url: https://github.com/kayak/pypika
   doc_url: https://pypika.readthedocs.io
   summary: A SQL query builder API for Python
+  description: |
+    PyPika is a Python API for building SQL queries. The motivation behind
+    PyPika is to provide a simple interface for building SQL queries
+    without limiting the flexibility of handwritten SQL. PyPika is a
+    fast, expressive and flexible way to replace handwritten SQL.
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,8 @@ test:
 
 about:
   home: https://github.com/kayak/pypika
+  dev_url: https://github.com/kayak/pypika
+  doc_url: https://pypika.readthedocs.io
   summary: A SQL query builder API for Python
   license: Apache-2.0
   license_family: APACHE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,45 @@
 {% set name = "pypika" %}
-{% set version = "0.48.8" %}
-
+{% set version = "0.51.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pypika-{{ version }}.tar.gz
-  sha256: 45af481d8523d60f87e308dee6ff5c454f331c8ce3a675e5398fbea6c20fe1b1
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - pip <21.3
-    - python >=3.6
+    - python
+    - pip
+    - setuptools
   run:
-    - python >=3.6
+    - python
+    - typing_extensions >=4.5.0  # [py<311]
 
 test:
   imports:
     - pypika
     - pypika.clickhouse
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/kayak/pypika
   summary: A SQL query builder API for Python
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:
     - mccarthyryanc
+    - thewchan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - python
     - pip
     - setuptools
-    - wheel
   run:
     - python
     - typing_extensions >=4.5.0  # [py<311]


### PR DESCRIPTION
pypika 0.51.1

**Destination channel:** defaults

### Links

- [PKG-14498](https://anaconda.atlassian.net/browse/PKG-14498) (blocks PKG-7382 chromadb)
- [Upstream repository](https://github.com/kayak/pypika)
- [Upstream changelog/diff](https://github.com/kayak/pypika/compare/0.48.8...0.51.1)
- Conda-forge recipe: https://github.com/conda-forge/pypika-feedstock/blob/main/recipe/recipe.yaml

### Explanation of changes:

- **First release of `pypika` to pkgs/main.** Existing AnacondaRecipes fork was at v0.48.8 (Feb 2025) and never released. Required as a runtime dep for chromadb 1.5.8 (PKG-7382).
- **Version bump 0.48.8 → 0.51.1** (latest upstream on PyPI).
- **Adaptations:**
  - Drop `noarch: python`; build per-Python with `skip: true  # [py<310]` to match the AnacondaRecipes Python matrix.
  - Add `typing_extensions >=4.5.0  # [py<311]` per [upstream `install_requires`](https://github.com/kayak/pypika/blob/0.51.1/setup.py).
  - Drop obsolete `pip <21.3` upper bound (legacy from pip 21.x setup-without-PEP517 days; no longer relevant).
  - Modern install flags: `--no-deps --no-build-isolation`.
  - Add `thewchan` to `recipe-maintainers` (preserved from conda-forge).
- **Upstream-verified runtime deps:** `setup.py` declares only `typing_extensions>=4.5.0; python_version < "3.11"`. No other runtime deps.

[PKG-14498]: https://anaconda.atlassian.net/browse/PKG-14498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ